### PR TITLE
reset and bind hotkeys for repeated open/close

### DIFF
--- a/script.js
+++ b/script.js
@@ -51,6 +51,8 @@ function bindMousetraps() {
 			Mousetrap.bind($(val).children('span').text(), function(e) {
 				$('.subMenu').slideUp(150);
 				$('li a').removeClass('active');
+				Mousetrap.reset();
+				bindMousetraps();
 			});
 		});
 	});


### PR DESCRIPTION
each time you hit a hotkey to close the dropdown, the bind was not reversed to open. hence, once you open and close a tab, it gets stuck

I saw this was not an issue with the esc button, so I followed the code, then reset the mousetraps on drop down close.
